### PR TITLE
fix affinity in cga-proxy helm-chart

### DIFF
--- a/charts/cga-proxy/Chart.yaml
+++ b/charts/cga-proxy/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for Barracuda CloudGen Access Proxy
 home: https://github.com/barracuda-cloudgen-access/helm-charts
 icon: https://raw.githubusercontent.com/barracuda-cloudgen-access/helm-charts/main/misc/CGA_ico_500x500.png
 type: application
-version: 0.2.7
+version: 0.2.8
 keywords:
   - barracuda
   - cloudgen

--- a/charts/cga-proxy/README.md
+++ b/charts/cga-proxy/README.md
@@ -1,6 +1,6 @@
 # cga-proxy
 
-![Version: 0.2.7](https://img.shields.io/badge/Version-0.2.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.2.8](https://img.shields.io/badge/Version-0.2.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for Barracuda CloudGen Access Proxy
 

--- a/charts/cga-proxy/templates/envoy/deployment.yaml
+++ b/charts/cga-proxy/templates/envoy/deployment.yaml
@@ -66,10 +66,9 @@ spec:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
-              matchExpressions:
+              matchLabels:
                 {{- include "cga-proxy.envoy.labels" . | nindent 16 }}
             topologyKey: kubernetes.io/hostname
-        podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100
               podAffinityTerm:

--- a/charts/cga-proxy/templates/orchestrator/deployment.yaml
+++ b/charts/cga-proxy/templates/orchestrator/deployment.yaml
@@ -81,10 +81,9 @@ spec:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
-              matchExpressions:
+              matchLabels:
                 {{- include "cga-proxy.orchestrator.labels" . | nindent 16 }}
             topologyKey: kubernetes.io/hostname
-        podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100
               podAffinityTerm:


### PR DESCRIPTION
Currently getting this error when trying to install this helm-chart inside the k8s cluster:
```
Helm install failed: error while running post render on files: map[string]interface {}(nil): yaml: unmarshal errors:
  line 62: mapping key "podAntiAffinity" already defined at line 56
```
# Summary
Removing duplicated `podAntiAffinity` block from both deployments.

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Local environment

# Checklist
<!-- Fill the checklist before opening the pull request -->

- [ ] Fill the description
- [ ] Declare the type of changes included in the pull request
- [ ] Describe how has this been tested
- [ ] Add categorical labels (feature/fix/chore/docs/skip-changelog)
- [ ] Add semver labels (patch/minor/major/skip-semver)
