### PR TITLE
Feat increase kind nodes

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -37,6 +37,8 @@ jobs:
       - name: Create kind cluster
         uses: helm/kind-action@v1.2.0
         if: steps.list-changed.outputs.changed == 'true'
+        with:
+          config: kind-config.yaml
 
       - name: Run chart-testing (install)
         env:

--- a/kind-config.yaml
+++ b/kind-config.yaml
@@ -1,0 +1,7 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+  - role: worker
+  - role: worker
+  - role: worker


### PR DESCRIPTION
<!-- If this is not ready to be reviewed create a draft pull request -->
# Summary
<!-- Include a summary of the change and which issue is fixed -->

Feat increase kind nodes

## Description
<!-- Include detailed description of the change when needed-->

After fixing the affinity rules for the cga-proxy chart on https://github.com/barracuda-cloudgen-access/helm-charts/pull/68, we need to increase kind nodes for future test to succeed

## Type of change
<!-- These are only examples you can change these however it fits -->

- Chore (tool, configuration, CI changes, or anything that doesn't reflect on the user)

## How Has This Been Tested?
<!-- Describe the tests that you ran to verify your changes. Provide instructions to reproduce -->

Theses changes have been tested in:

- Job [helm-charts/runs/6623334167](https://github.com/barracuda-cloudgen-access/helm-charts/runs/6623334167?check_suite_focus=true) with validation for step `Create kind cluster` disabled to force execution